### PR TITLE
ExchangeSubscription Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
-# SpiceFlow
+# 🔮 SpiceFlow
+
+**SpiceFlow** is a real-time, multi-venue market data system built in Rust. It orchestrates WebSocket connections to crypto exchanges like **Deribit** and **Binance**, managing subscriptions to market data feeds such as order books.
+
+The system is powered by a modular, actor-based architecture — separating concerns like:
+- Reference data fetching
+- WebSocket orchestration
+- Order book management
+- Broadcasting of processed data
+
+It’s designed for high performance, scalability, and observability, with an emphasis on reliability and support for rapid multi-exchange expansion.
+
+---
+
+## 🚀 Features
+
+- 📡 WebSocket streaming from multiple exchanges
+- ⚙️ Modular actor-based orchestration system
+- 🧮 Real-time order book construction
+- 📤 ZeroMQ broadcasting layer
+- 🧪 Offline fixtures for dev/testing
+- 🔍 Tracing instrumentation
+
+---
 
 
 ### 🧪 Dev Fixtures

--- a/server/src/async_actors/deribit/mod.rs
+++ b/server/src/async_actors/deribit/mod.rs
@@ -1,8 +1,8 @@
 // server/src/async_actors/deribit/mod.rs
 
-pub mod orderbook;
-pub mod router;
-pub mod websocket;
+mod orderbook;
+mod router;
+mod websocket;
 pub use orderbook::DeribitOrderBookActor;
 pub use router::DeribitRouterActor;
 pub use websocket::DeribitWebSocketActor;

--- a/server/src/async_actors/deribit/orderbook.rs
+++ b/server/src/async_actors/deribit/orderbook.rs
@@ -102,7 +102,7 @@ pub struct RawOrderBookData {
     #[serde(rename = "type")]
     pub msg_type: OrderBookMessageType,
     pub timestamp: u64,
-    pub instrument_name: String,
+    // pub instrument_name: String,
     pub change_id: u64,
     pub bids: Vec<RawOrderBookEntry>,
     pub asks: Vec<RawOrderBookEntry>,
@@ -151,7 +151,7 @@ impl DeribitOrderBookActor {
         let span: tracing::Span = tracing::info_span!(
             "DeribitOrderBookActor",
             actor_id = %self.actor_id,
-            stream_id = %self.subscription.stream_id(),
+            stream_id = %self.subscription.stream_id,
         );
 
         async move {
@@ -347,7 +347,7 @@ impl DeribitOrderBookActor {
             .collect();
 
         let data = ProcessedMarketData::OrderBook(ProcessedOrderBookData {
-            stream_id: self.subscription.stream_id().to_string(),
+            stream_id: self.subscription.stream_id.clone(),
             exchange_timestamp: self.exchange_timestamp.unwrap_or(0),
             bids,
             asks,

--- a/server/src/async_actors/mod.rs
+++ b/server/src/async_actors/mod.rs
@@ -4,3 +4,4 @@ pub mod broadcast;
 pub mod deribit;
 pub mod messages;
 pub mod orchestrator;
+pub use orchestrator::Orchestrator;

--- a/server/src/async_actors/orchestrator/mod.rs
+++ b/server/src/async_actors/orchestrator/mod.rs
@@ -1,7 +1,8 @@
 // server/src/async_actors/orchestrator/mod.rs
 
-pub mod errors;
-pub mod meta;
-pub mod orch;
-pub mod tasks;
+mod errors;
+mod meta;
+mod orch;
+mod tasks;
 pub use orch::Orchestrator;
+pub use errors::OrchestratorError;

--- a/server/src/async_actors/orchestrator/tasks.rs
+++ b/server/src/async_actors/orchestrator/tasks.rs
@@ -7,10 +7,12 @@ use std::fmt;
 use tracing::info;
 
 // 🧠 Internal Crates / Modules
-use super::errors::OrchestratorError;
-use crate::async_actors::orchestrator::orch::Orchestrator;
 use crate::domain::ExchangeSubscription;
 use crate::model::Exchange;
+
+// 🧩 Local Module
+use super::errors::OrchestratorError;
+use super::orch::Orchestrator;
 
 pub enum WorkflowKind {
     Subscribe,
@@ -34,12 +36,7 @@ pub struct Workflow {
 
 impl fmt::Display for Workflow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}Workflow [{}]",
-            self.kind,
-            self.subscription.stream_id()
-        )
+        write!(f, "{}Workflow [{}]", self.kind, self.subscription.stream_id)
     }
 }
 
@@ -63,7 +60,7 @@ impl Workflow {
                     subscription: self.subscription.clone(),
                 }),
                 3 => Some(OrchestratorTask::CreateRouterIfNeeded {
-                    exchange: self.subscription.exchange(),
+                    exchange: self.subscription.exchange,
                 }),
                 4 => Some(OrchestratorTask::SubscribeRouter {
                     subscription: self.subscription.clone(),
@@ -126,12 +123,12 @@ impl fmt::Display for OrchestratorTask {
             OrchestratorTask::CreateOrderBook { subscription } => write!(
                 f,
                 "OrchestratorTask::Unsubscribe {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
             OrchestratorTask::OrderBookCreated { subscription } => write!(
                 f,
                 "OrchestratorTask::OrderBookCreated {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
             OrchestratorTask::CreateRouterIfNeeded { exchange } => {
                 write!(f, "OrchestratorTask::CreateRouterIfNeeded {}", exchange)
@@ -142,32 +139,32 @@ impl fmt::Display for OrchestratorTask {
             OrchestratorTask::SubscribeRouter { subscription } => write!(
                 f,
                 "OrchestratorTask::SubscribeRouter {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
             OrchestratorTask::SubscribeWebSocket { subscription } => write!(
                 f,
                 "OrchestratorTask::SubscribeWebSocket {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
             OrchestratorTask::WebSocketSubscribed { subscription } => write!(
                 f,
                 "OrchestratorTask::WebSocketSubscribed {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
             OrchestratorTask::UnsubscribeWebSocket { subscription } => write!(
                 f,
                 "OrchestratorTask::UnsubscribeWebSocket {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
             OrchestratorTask::UnsubscribeRouter { subscription } => write!(
                 f,
                 "OrchestratorTask::UnsubscribeRouter {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
             OrchestratorTask::TeardownOrderBook { subscription } => write!(
                 f,
                 "OrchestratorTask::TeardownOrderBook {}",
-                subscription.stream_id()
+                subscription.stream_id
             ),
         }
     }
@@ -221,13 +218,13 @@ impl OrchestratorTask {
                 match orch
                     .orderbooks
                     .values()
-                    .find(|meta| meta.subscription.stream_id() == subscription.stream_id())
+                    .find(|meta| meta.subscription.stream_id == subscription.stream_id)
                 {
                     Some(meta) => {
                         if meta.is_ready() {
                             info!(
                                 "✅ Completed OrchestratorTask::CreateOrderBook for {}",
-                                subscription.stream_id()
+                                subscription.stream_id
                             );
                             TaskOutcome::Complete
                         } else {
@@ -254,7 +251,7 @@ impl OrchestratorTask {
                 let router_actor_id = match orch
                     .routers
                     .iter()
-                    .find(|(_, meta)| meta.exchange == subscription.exchange())
+                    .find(|(_, meta)| meta.exchange == subscription.exchange)
                     .map(|(id, _)| id.clone())
                 {
                     Some(id) => id,
@@ -274,7 +271,7 @@ impl OrchestratorTask {
                         let router_actor_id = match orch
                             .routers
                             .iter()
-                            .find(|(_, meta)| meta.exchange == subscription.exchange())
+                            .find(|(_, meta)| meta.exchange == subscription.exchange)
                             .map(|(id, _)| id.clone())
                         {
                             Some(id) => id,
@@ -284,7 +281,7 @@ impl OrchestratorTask {
                         };
 
                         match orch
-                            .create_websocket_actor(&subscription.exchange(), &router_actor_id)
+                            .create_websocket_actor(&subscription.exchange, &router_actor_id)
                             .await
                         {
                             Ok(new_id) => new_id,
@@ -305,7 +302,7 @@ impl OrchestratorTask {
             OrchestratorTask::WebSocketSubscribed { subscription } => {
                 match orch.websockets.iter().find(|(_actor_id, meta)| {
                     meta.subscribed_streams
-                        .contains_key(subscription.stream_id())
+                        .contains_key(&subscription.stream_id)
                 }) {
                     Some(_) => TaskOutcome::Complete,
                     None => TaskOutcome::Pending,
@@ -318,7 +315,7 @@ impl OrchestratorTask {
                     .values()
                     .find(|meta| {
                         meta.subscribed_streams
-                            .contains_key(subscription.stream_id())
+                            .contains_key(&subscription.stream_id)
                     })
                     .map(|meta| meta.actor_id.clone())
                 {
@@ -337,7 +334,7 @@ impl OrchestratorTask {
                     .values()
                     .find(|meta| {
                         meta.subscribed_streams
-                            .contains_key(subscription.stream_id())
+                            .contains_key(&subscription.stream_id)
                     })
                     .map(|meta| meta.actor_id.clone())
                 {
@@ -357,7 +354,7 @@ impl OrchestratorTask {
                 let orderbook_actor_id = match orch
                     .orderbooks
                     .iter()
-                    .find(|(_, meta)| meta.subscription.stream_id() == subscription.stream_id())
+                    .find(|(_, meta)| meta.subscription.stream_id == subscription.stream_id)
                     .map(|(key, _)| key.clone())
                 {
                     Some(id) => id,

--- a/server/src/domain/mod.rs
+++ b/server/src/domain/mod.rs
@@ -4,4 +4,4 @@ pub mod instrument;
 pub mod ref_data;
 pub mod subscription;
 pub use ref_data::RefDataService;
-pub use subscription::{BinanceSubscription, DeribitSubscription, ExchangeSubscription};
+pub use subscription::ExchangeSubscription;

--- a/server/src/domain/ref_data/binance.rs
+++ b/server/src/domain/ref_data/binance.rs
@@ -12,7 +12,7 @@ use crate::domain::instrument::{
     BinanceInstrumentSource, BinanceSymbol, ExchangeInstruments, Instrument,
 };
 use crate::domain::ref_data::ExchangeRefDataProvider;
-use crate::domain::{BinanceSubscription, ExchangeSubscription};
+use crate::domain::ExchangeSubscription;
 use crate::http_api::SubscriptionRequest;
 use crate::model::InstrumentType;
 
@@ -144,12 +144,12 @@ impl ExchangeRefDataProvider for BinanceRefData {
         let internal_symbol = instrument.to_internal_symbol();
         let exchange_symbol = instrument.exchange_symbol.clone();
 
-        Ok(ExchangeSubscription::from(BinanceSubscription::new(
+        Ok(ExchangeSubscription::new(
             internal_symbol,
             exchange_symbol,
             request.requested_feed,
             instrument.exchange,
-        )))
+        ))
     }
 
     async fn resolve_request(
@@ -256,7 +256,7 @@ mod tests {
             .await
             .expect("resolve_request should succeed");
 
-        assert_eq!(subscription.exchange_symbol(), "BTCUSDT");
-        assert!(subscription.stream_id().contains("BTC"));
+        assert_eq!(subscription.exchange_symbol, "BTCUSDT");
+        assert!(subscription.stream_id.contains("BTC"));
     }
 }

--- a/server/src/domain/ref_data/deribit.rs
+++ b/server/src/domain/ref_data/deribit.rs
@@ -10,7 +10,7 @@ use url::Url;
 use super::types::RefDataError;
 use crate::domain::instrument::{DeribitInstrument, ExchangeInstruments, Instrument};
 use crate::domain::ref_data::ExchangeRefDataProvider;
-use crate::domain::{DeribitSubscription, ExchangeSubscription};
+use crate::domain::ExchangeSubscription;
 use crate::http_api::SubscriptionRequest;
 use crate::model::InstrumentType;
 
@@ -112,12 +112,12 @@ impl ExchangeRefDataProvider for DeribitRefData {
         let internal_symbol = instrument.to_internal_symbol();
         let exchange_symbol = instrument.exchange_symbol.clone();
 
-        Ok(ExchangeSubscription::from(DeribitSubscription::new(
+        Ok(ExchangeSubscription::new(
             internal_symbol,
             exchange_symbol,
             request.requested_feed,
             instrument.exchange,
-        )))
+        ))
     }
 
     async fn resolve_request(
@@ -218,7 +218,7 @@ mod tests {
             .await
             .expect("resolve_request should succeed");
 
-        assert_eq!(subscription.exchange_symbol(), "BTC-PERPETUAL");
-        assert!(subscription.stream_id().contains("BTC"));
+        assert_eq!(subscription.exchange_symbol, "BTC-PERPETUAL");
+        assert!(subscription.stream_id.contains("BTC"));
     }
 }

--- a/server/src/domain/subscription/mod.rs
+++ b/server/src/domain/subscription/mod.rs
@@ -1,171 +1,50 @@
 // server/src/domain/subscription/mod.rs
 
+// 🧠 Internal modules
 use crate::model::{Exchange, RequestedFeed};
 
-pub type ExchangeSubscription = Box<dyn SubscriptionInfo>;
 
-impl From<DeribitSubscription> for ExchangeSubscription {
-    fn from(sub: DeribitSubscription) -> Self {
-        Box::new(sub)
-    }
-}
-
-impl From<BinanceSubscription> for ExchangeSubscription {
-    fn from(sub: BinanceSubscription) -> Self {
-        Box::new(sub)
-    }
-}
-
-pub trait SubscriptionInfo: std::fmt::Debug + Send + Sync {
-    fn stream_id(&self) -> &str;
-    fn exchange_symbol(&self) -> &str;
-    fn exchange_stream_id(&self) -> &str;
-    fn feed_type(&self) -> RequestedFeed;
-    fn exchange(&self) -> Exchange;
-    fn clone_box(&self) -> Box<dyn SubscriptionInfo>;
-}
-
-impl Clone for Box<dyn SubscriptionInfo> {
-    fn clone(&self) -> Self {
-        self.clone_box()
-    }
-}
-
-#[derive(Debug)]
-pub struct DeribitSubscription {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExchangeSubscription {
     pub internal_symbol: String,
     pub exchange_symbol: String,
     pub requested_feed: RequestedFeed,
-    pub stream_id: String,
     pub exchange_stream_id: String,
+    pub stream_id: String,
     pub exchange: Exchange,
 }
 
-impl Clone for DeribitSubscription {
-    fn clone(&self) -> Self {
-        Self {
-            internal_symbol: self.internal_symbol.clone(),
-            exchange_symbol: self.exchange_symbol.clone(),
-            requested_feed: self.requested_feed,
-            stream_id: self.stream_id.clone(),
-            exchange_stream_id: self.exchange_stream_id.clone(),
-            exchange: self.exchange,
-        }
-    }
-}
-
-impl SubscriptionInfo for DeribitSubscription {
-    fn stream_id(&self) -> &str {
-        &self.stream_id
-    }
-    fn exchange_symbol(&self) -> &str {
-        &self.exchange_symbol
-    }
-    fn exchange_stream_id(&self) -> &str {
-        &self.exchange_stream_id
-    }
-    fn feed_type(&self) -> RequestedFeed {
-        self.requested_feed
-    }
-    fn exchange(&self) -> Exchange {
-        self.exchange
-    }
-    fn clone_box(&self) -> Box<dyn SubscriptionInfo> {
-        Box::new(self.clone())
-    }
-}
-
-impl DeribitSubscription {
+impl ExchangeSubscription {
     pub fn new(
         internal_symbol: String,
         exchange_symbol: String,
         requested_feed: RequestedFeed,
         exchange: Exchange,
     ) -> Self {
-        let stream_id = format!("{}.{}", internal_symbol, requested_feed);
-        let exchange_stream_id = match requested_feed {
-            RequestedFeed::OrderBook => format!("book.{}.100ms", &exchange_symbol),
+        let exchange_stream_id = match exchange {
+            Exchange::Deribit => deribit_stream_id(&exchange_symbol, requested_feed),
+            Exchange::Binance => binance_stream_id(&exchange_symbol, requested_feed),
         };
-
+        let stream_id = format!("{}.{}", internal_symbol, requested_feed);
         Self {
             internal_symbol,
             exchange_symbol,
             requested_feed,
-            stream_id,
             exchange_stream_id,
+            stream_id,
             exchange,
         }
     }
 }
 
-#[derive(Debug)]
-pub struct BinanceSubscription {
-    pub internal_symbol: String,
-    pub exchange_symbol: String,
-    pub requested_feed: RequestedFeed,
-    pub stream_id: String,
-    pub exchange_stream_id: String,
-    pub exchange: Exchange,
-}
-
-impl Clone for BinanceSubscription {
-    fn clone(&self) -> Self {
-        Self {
-            internal_symbol: self.internal_symbol.clone(),
-            exchange_symbol: self.exchange_symbol.clone(),
-            requested_feed: self.requested_feed,
-            stream_id: self.stream_id.clone(),
-            exchange_stream_id: self.exchange_stream_id.clone(),
-            exchange: self.exchange,
-        }
+fn deribit_stream_id(exchange_symbol: &str, requested_feed: RequestedFeed) -> String {
+    match requested_feed {
+        RequestedFeed::OrderBook => format!("book.{}.100ms", &exchange_symbol),
     }
 }
 
-impl SubscriptionInfo for BinanceSubscription {
-    fn stream_id(&self) -> &str {
-        &self.stream_id
-    }
-
-    fn exchange_symbol(&self) -> &str {
-        &self.exchange_symbol
-    }
-
-    fn exchange_stream_id(&self) -> &str {
-        &self.exchange_stream_id
-    }
-
-    fn feed_type(&self) -> RequestedFeed {
-        self.requested_feed
-    }
-
-    fn exchange(&self) -> Exchange {
-        self.exchange
-    }
-
-    fn clone_box(&self) -> Box<dyn SubscriptionInfo> {
-        Box::new(self.clone())
-    }
-}
-
-impl BinanceSubscription {
-    pub fn new(
-        internal_symbol: String,
-        exchange_symbol: String,
-        requested_feed: RequestedFeed,
-        exchange: Exchange,
-    ) -> Self {
-        let stream_id = format!("{}.{}", internal_symbol, requested_feed);
-        let exchange_stream_id = match requested_feed {
-            RequestedFeed::OrderBook => format!("{}@depth@100ms", exchange_symbol.to_lowercase()),
-        };
-
-        Self {
-            internal_symbol,
-            exchange_symbol,
-            requested_feed,
-            stream_id,
-            exchange_stream_id,
-            exchange,
-        }
+fn binance_stream_id(exchange_symbol: &str, requested_feed: RequestedFeed) -> String {
+    match requested_feed {
+        RequestedFeed::OrderBook => format!("book.{}.100ms", &exchange_symbol),
     }
 }

--- a/server/src/http_api/handle.rs
+++ b/server/src/http_api/handle.rs
@@ -4,7 +4,7 @@
 use tokio::sync::mpsc;
 
 // 🧠 Internal modules
-use crate::async_actors::orchestrator::errors::OrchestratorError;
+use crate::async_actors::orchestrator::OrchestratorError;
 use crate::domain::ExchangeSubscription;
 
 #[derive(Debug, Clone)]

--- a/server/src/http_api/mod.rs
+++ b/server/src/http_api/mod.rs
@@ -1,8 +1,8 @@
 // server/src/http_api/mod.rs
 
-pub mod handle;
+mod handle;
 mod request_handler;
 mod requests;
-pub use handle::OrchestratorHandle;
+pub use handle::{OrchestratorHandle,SubscriptionAction};
 pub use request_handler::start_http_server;
 pub use requests::SubscriptionRequest;

--- a/server/src/http_api/request_handler.rs
+++ b/server/src/http_api/request_handler.rs
@@ -84,7 +84,7 @@ async fn handle_subscription_action(
     match state.ref_data.resolve_request(&request).await {
         Ok(subscription) => {
             info!("✅ Resolved subscription: {:?}", subscription);
-            let stream_id = subscription.stream_id().to_string();
+            let stream_id = subscription.stream_id.clone();
             let action = action_builder(subscription);
 
             if let Err(e) = state.orchestrator_handle.send(action).await {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,7 +9,7 @@ use tracing::info;
 // 🧠 Internal modules
 use server::async_actors::orchestrator::Orchestrator;
 use server::domain::RefDataService;
-use server::http_api::{handle::SubscriptionAction, start_http_server, OrchestratorHandle};
+use server::http_api::{SubscriptionAction, start_http_server, OrchestratorHandle};
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Flattens the `ExchangeSubscription` model, removing per-exchange trait objects in favor of a unified, transparent struct that carries all necessary metadata. 

**What's changed:**
- Introduced a single `ExchangeSubscription` struct with all fields inline.
- Encapsulated per-exchange stream formatting in helper functions, called once during construction.
- Updated all calling code (RefData services, Orchestrator, WebSocket, Router, OrderBook) to use the new structure.
- Removed dynamic dispatch and clone boilerplate from `SubscriptionInfo` trait implementations.
- Resolved Clippy warnings across the board.

**Benefits:**
- Simplified code paths and reduced type complexity.
- Improved testability and introspection of subscription state.
- Better performance characteristics by reducing heap indirection.
- Leaner and more maintainable going forward, especially as new venues and feeds are added.